### PR TITLE
Allow additional Direwolf configuration via Dirus

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,20 @@ Plus:
 
 That's it! Install one FM Decoder, Dire Wolf, and Dirus and you're off to the races!
 
+Configuration
+=====
+A sample dirus.json file is included in the repository, showing the options you can
+configure across the two applications. Most defaults will work out-of-the-box, but
+you may need to update a few:
+
+**path**: Defines the full path to rtl_fm or rx_fm, and direwolf.
+**frequency**: Update to ensure the SDR listens on the right APRS frequency for your region.
+**ppm**: Adjusts for natural errors in most RTL chipsets. Run `rtl_test -p` for at least 10 minutes to determine the error rate for your particular unit.
+**gain** _(Optional)_: Set the manual gain for your RTL in dB, or leave at 0 to set to automatic (recommended)
+**device_index**: Allows you to run dirus with multiple SDR units attached. Use `rtl_test` to identify devices available and their index.
+**sample_rate**: Determines the audio sample rate (in Hz) used between rtl_fm and direwolf. The default of 44100 is sufficient for 1200 baud AFSK.
+**conf**: Point to the configuration file for Direwolf, or leave blank to use a very simple, basic config that depends on Direwolf's defaults.
+
 Usage
 =====
 
@@ -67,9 +81,19 @@ Source
 ======
 Github: https://github.com/ampledata/dirus
 
+Building from Source
+======
+A simple `make` file is included in the source. To build, you only need the basic `python2.7-dev` and `libpython2.7-dev` packages installed.
+
+As implied, Dirus uses Python 2, not Python 3.
+
 Author
 ======
 Greg Albrecht W2GMD <oss@undef.net>
+
+Contributors
+======
+Will Davidson KD8DRX <will@kilodelta.com>
 
 Copyright
 =========

--- a/README.rst
+++ b/README.rst
@@ -35,11 +35,17 @@ configure across the two applications. Most defaults will work out-of-the-box, b
 you may need to update a few:
 
 **path**: Defines the full path to rtl_fm or rx_fm, and direwolf.
+
 **frequency**: Update to ensure the SDR listens on the right APRS frequency for your region.
+
 **ppm**: Adjusts for natural errors in most RTL chipsets. Run `rtl_test -p` for at least 10 minutes to determine the error rate for your particular unit.
+
 **gain** _(Optional)_: Set the manual gain for your RTL in dB, or leave at 0 to set to automatic (recommended)
+
 **device_index**: Allows you to run dirus with multiple SDR units attached. Use `rtl_test` to identify devices available and their index.
+
 **sample_rate**: Determines the audio sample rate (in Hz) used between rtl_fm and direwolf. The default of 44100 is sufficient for 1200 baud AFSK.
+
 **conf**: Point to the configuration file for Direwolf, or leave blank to use a very simple, basic config that depends on Direwolf's defaults.
 
 Usage

--- a/dirus.json
+++ b/dirus.json
@@ -1,5 +1,6 @@
 {
     "rtl": {
+        "path": "/usr/local/bin/rtl_fm",
         "frequency": 144.390,
         "ppm": 4.384,
         "gain": 0,
@@ -9,6 +10,6 @@
     },
     "direwolf": {
         "path": "/usr/local/bin/direwolf",
-        "config_file": "/etc/direwolf/direwolf.conf"
+        "conf": "/etc/direwolf/direwolf.conf"
     }
 }

--- a/dirus.json
+++ b/dirus.json
@@ -6,5 +6,9 @@
         "offset_tuning": false,
         "device_index": 0,
         "sample_rate": 44100
+    },
+    "direwolf": {
+        "path": "/usr/local/bin/direwolf",
+        "config_file": "/etc/direwolf/direwolf.conf"
     }
 }

--- a/dirus/classes.py
+++ b/dirus/classes.py
@@ -50,9 +50,9 @@ class Dirus(threading.Thread):
         os.close(tmp_fd)
 
     def run(self):
-
+        # Configure / Run SDR
         # Allow use of 'rx_fm' for Soapy/HackRF
-        rtl_cmd = self.config['rtl'].get('command', 'rtl_fm')
+        rtl_path = self.config['rtl'].get('path', 'rtl_fm')
 
         frequency = "%sM" % self.config['rtl']['frequency']
         sample_rate = self.config['rtl'].get('sample_rate', dirus.SAMPLE_RATE)
@@ -65,7 +65,7 @@ class Dirus(threading.Thread):
         else:
             enable_option = 'none'
 
-        src_cmd = [rtl_cmd]
+        src_cmd = [rtl_path]
         src_cmd.extend(('-f', frequency))
         src_cmd.extend(('-s', sample_rate))
         src_cmd.extend(('-E', enable_option))
@@ -90,30 +90,33 @@ class Dirus(threading.Thread):
 
         self.processes['src'] = src_proc
 
-        direwolf_cmd = self.config['direwolf'].get('path', 'direwolf')
-        direwolf_config_path = self.config['direwolf'].get('config_file')
+        ## Configure / Run Direwolf
+        direwolf_path = self.config['direwolf'].get('command', 'direwolf')                
+        direwolf_conf = self.config['direwolf'].get('conf')
 
+        dw_cmd = [direwolf_path]
         # Configuration file name.
-        if direwolf_config_path is not None:
-            direwolf_cmd.extend(('-c', direwolf_config_path))
+        if direwolf_conf is not None:
+            dw_cmd.extend(('-c', direwolf_conf))
         else:
             self._write_direwolf_conf()
-            direwolf_cmd.extend(('-c', self.direwolf_conf))
+            dw_cmd.extend(('-c', self.direwolf_conf))
+        
         # Text colors.  1=normal, 0=disabled.
-        direwolf_cmd.extend(('-t', 0))
+        dw_cmd.extend(('-t', 0))
         # Number of audio channels, 1 or 2.
-        direwolf_cmd.extend(('-n', 1))
+        dw_cmd.extend(('-n', 1))
         # Bits per audio sample, 8 or 16.
-        direwolf_cmd.extend(('-b', 16))
+        dw_cmd.extend(('-b', 16))
         # Read from STDIN.
-        direwolf_cmd.append('-')
+        dw_cmd.append('-')
 
-        direwolf_cmd = map(str, direwolf_cmd)
+        dw_cmd = map(str, dw_cmd)
 
-        self._logger.debug('direwolf_cmd="%s"', ' '.join(direwolf_cmd))
+        self._logger.debug('dw_cmd="%s"', ' '.join(dw_cmd))
 
         direwolf_proc = subprocess.Popen(
-            direwolf_cmd,
+            dw_cmd,
             stdin=self.processes['src'].stdout,
             stdout=subprocess.PIPE
         )

--- a/dirus/classes.py
+++ b/dirus/classes.py
@@ -43,13 +43,13 @@ class Dirus(threading.Thread):
         self.stop()
 
     def _write_direwolf_conf(self):
+        
         tmp_fd, self.direwolf_conf = tempfile.mkstemp(
             prefix='dirus_', suffix='.conf')
         os.write(tmp_fd, "ADEVICE null null\n")
         os.close(tmp_fd)
 
     def run(self):
-        self._write_direwolf_conf()
 
         # Allow use of 'rx_fm' for Soapy/HackRF
         rtl_cmd = self.config['rtl'].get('command', 'rtl_fm')
@@ -90,10 +90,15 @@ class Dirus(threading.Thread):
 
         self.processes['src'] = src_proc
 
-        direwolf_cmd = ['direwolf']
+        direwolf_cmd = self.config['direwolf'].get('path', 'direwolf')
+        direwolf_config_path = self.config['direwolf'].get('config_file')
 
         # Configuration file name.
-        direwolf_cmd.extend(('-c', self.direwolf_conf))
+        if direwolf_config_path is not None:
+            direwolf_cmd.extend(('-c', direwolf_config_path))
+        else:
+            self._write_direwolf_conf()
+            direwolf_cmd.extend(('-c', self.direwolf_conf))
         # Text colors.  1=normal, 0=disabled.
         direwolf_cmd.extend(('-t', 0))
         # Number of audio channels, 1 or 2.

--- a/dirus/classes.py
+++ b/dirus/classes.py
@@ -68,6 +68,7 @@ class Dirus(threading.Thread):
         src_cmd = [rtl_path]
         src_cmd.extend(('-f', frequency))
         src_cmd.extend(('-s', sample_rate))
+        src_cmd.extend(('-r', sample_rate))
         src_cmd.extend(('-E', enable_option))
         src_cmd.extend(('-d', device_index))
 
@@ -106,6 +107,8 @@ class Dirus(threading.Thread):
         dw_cmd.extend(('-t', 0))
         # Number of audio channels, 1 or 2.
         dw_cmd.extend(('-n', 1))
+        # Resample rate coming from rtl_fm. Synced with settings from rtl_fm.
+        dw_cmd.extend(('-s', sample_rate))
         # Bits per audio sample, 8 or 16.
         dw_cmd.extend(('-b', 16))
         # Read from STDIN.

--- a/dirus/classes.py
+++ b/dirus/classes.py
@@ -108,7 +108,7 @@ class Dirus(threading.Thread):
         # Number of audio channels, 1 or 2.
         dw_cmd.extend(('-n', 1))
         # Resample rate coming from rtl_fm. Synced with settings from rtl_fm.
-        dw_cmd.extend(('-s', sample_rate))
+        dw_cmd.extend(('-r', sample_rate))
         # Bits per audio sample, 8 or 16.
         dw_cmd.extend(('-b', 16))
         # Read from STDIN.


### PR DESCRIPTION
A bundle of updates to the code, primarily focused on improving the ability to manage settings using the `dirus.json` file. Testing was done on my MacBook Pro running macOS 10.13.6 and a Raspberry Pi 3 with Raspbian Jesse.

I do hope these features prove useful to the rest of the amateur radio community. This is a super helpful tool for automating some of these backend processes that make the hobby fun!

#### Features Added:

- Added a separate `direwolf` json dict that allows you to
  - Set a Direwolf config file via the _path_ key
  - Set the path to Direwolf, assuming it's not in your $PATH
- Added Direwolf argument for `sample_rate`, ensuring it is synced with the sample rate used in rtl_fm. In my testing, this is often required to ensure proper decoding of packets.
- Updated `README.rst` with build, configuration, and contributor sections based.

#### Other Minor Changes:

- Changed internal variables for Direwolf and rtl_sdr commands to better differentiate between them, and make the code read a little better (I hope?)

- Small changes in the Direwolf commands to deal with Python 2's fun handling of strings vs. unicode.